### PR TITLE
small change to fix Test::NoWarnings failures

### DIFF
--- a/lib/CatalystX/I18N/Role/Base.pm
+++ b/lib/CatalystX/I18N/Role/Base.pm
@@ -82,7 +82,7 @@ sub set_locale {
         unless $value =~ $CatalystX::I18N::TypeConstraints::LOCALE_RE;
     
     my $language = lc($1);
-    my $territory = uc($2);
+    my $territory = $2 && uc($2);
     my $locale = lc($language);
     $locale .= '_'.uc($territory)
         if defined $territory && $territory ne '';


### PR DESCRIPTION
Hello,

I had to make this small change to get the tests to pass when $value gets set to something like 'fr' (when the locale dosen't have the territory part).

Thank you,

Todd W.
