### PR TITLE
Fixed a typo in a method name.

### DIFF
--- a/lib/CatalystX/I18N/Role/DateTime.pm
+++ b/lib/CatalystX/I18N/Role/DateTime.pm
@@ -113,7 +113,7 @@ sub _build_i18n_datetime_format_datetime {
     my $config = $c->i18n_config;
     
     my $datetime_locale = $c->i18n_datetime_locale;
-    my $datetime_timezone = $c->i18n_datetime_timezone;
+    my $datetime_timezone = $c->i18n_timezone;
     
     # Set datetime_format_date
     my $datetime_format_datetime =


### PR DESCRIPTION
Not sure if i18n_timezone needs to be renamed to i18n_datetime_timezone, but might break other installs out there. Maybe rename and create an alias? But for now, I fixed the code without the rename.
