### PR TITLE
fix(warnings) remove disturbing undefined warnings

### DIFF
--- a/lib/CatalystX/I18N/Role/GetLocale.pm
+++ b/lib/CatalystX/I18N/Role/GetLocale.pm
@@ -70,7 +70,7 @@ sub get_locale_from_browser  {
     }
     
     # Get browser language
-    if ($c->request->can('browser_language')) {
+    if ( $c->request->user_agent && $c->request->can('browser_language')) {
         my $language = $c->request->browser_language;
         if ($language) {
             unshift(@$languages,$language)

--- a/lib/CatalystX/I18N/TraitFor/Request.pm
+++ b/lib/CatalystX/I18N/TraitFor/Request.pm
@@ -93,6 +93,9 @@ sub _build_accept_language {
 sub _build_browser_language {
     my ($self) = @_;
     
+    # browser_detect->language warns unless user_agent
+    return unless $self->user_agent;
+
     my $language = $self->browser_detect()->language();
     
     return
@@ -111,7 +114,10 @@ sub _build_browser_language {
 
 sub _build_browser_territory {
     my ($self) = @_;
-    
+
+    # browser_detect->country warns unless user_agent
+    return unless $self->user_agent;
+
     my $territory = $self->browser_detect()->country();
     
     return


### PR DESCRIPTION
Prevent HTTP::BrowserDetect to run into not defined warnings by not
calling it unless we have a valid user_agent. Unfortunately there are
some clients out there that try to set User-Agent:  to empty string and
those cause a lot of warnings.
